### PR TITLE
Add last-opened sort for All Books

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -58,6 +58,7 @@
               <option value="title_desc" data-i18n="library.sort_title_za">Naslov Z–A</option>
               <option value="author_asc" data-i18n="library.sort_author_az">Avtor A–Z</option>
               <option value="progress_desc" data-i18n="library.sort_progress">Napredek</option>
+              <option value="opened_desc" data-i18n="library.sort_last_opened">Nazadnje odprto</option>
               <option value="series_asc" data-i18n="library.sort_series">Serija</option>
             </select>
             <button id="sort-menu-btn" class="sort-menu-btn" aria-haspopup="listbox" aria-expanded="false" aria-controls="sort-menu-list" title="Razvrsti knjige">

--- a/public/js/library.js
+++ b/public/js/library.js
@@ -77,7 +77,8 @@ function sortBooks(list) {
   const sorted = [...list];
   // In "Currently Reading" view, default to last-read order when the user hasn't overridden the sort
   if (currentShelfId === 'reading' && order === 'added_desc') {
-    return sorted.sort((a, b) => (b.progress_updated_at || 0) - (a.progress_updated_at || 0));
+    return sorted.sort((a, b) =>
+      (b.last_opened_at || b.added_at || 0) - (a.last_opened_at || a.added_at || 0));
   }
   switch (order) {
     case 'added_desc':    sorted.sort((a, b) => b.added_at - a.added_at); break;
@@ -86,6 +87,8 @@ function sortBooks(list) {
     case 'title_desc':    sorted.sort((a, b) => b.title.localeCompare(a.title)); break;
     case 'author_asc':    sorted.sort((a, b) => (a.author || '').localeCompare(b.author || '')); break;
     case 'progress_desc': sorted.sort((a, b) => (b.percentage || 0) - (a.percentage || 0)); break;
+    case 'opened_desc':   sorted.sort((a, b) =>
+      (b.last_opened_at || b.added_at || 0) - (a.last_opened_at || a.added_at || 0)); break;
     case 'series_asc':    sorted.sort((a, b) => {
       const sc = (a.series_name || '').localeCompare(b.series_name || '');
       if (sc !== 0) return sc;

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -51,6 +51,7 @@
   "library.sort_title_za": "Titel Z–A",
   "library.sort_author_az": "Autor A–Z",
   "library.sort_progress": "Fortschritt",
+  "library.sort_last_opened": "Zuletzt geöffnet",
   "library.sort_series": "Reihe",
   "library.btn_edit": "Bearbeiten",
   "library.add_book": "Buch hinzufügen",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -51,6 +51,7 @@
   "library.sort_title_za": "Title Z–A",
   "library.sort_author_az": "Author A–Z",
   "library.sort_progress": "Progress",
+  "library.sort_last_opened": "Last opened",
   "library.sort_series": "Series",
   "library.btn_edit": "Edit",
   "library.add_book": "Add book",

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -51,6 +51,7 @@
   "library.sort_title_za": "Título Z–A",
   "library.sort_author_az": "Autor A–Z",
   "library.sort_progress": "Progreso",
+  "library.sort_last_opened": "Última apertura",
   "library.sort_series": "Serie",
   "library.btn_edit": "Editar",
   "library.add_book": "Añadir libro",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -51,6 +51,7 @@
   "library.sort_title_za": "Titre Z–A",
   "library.sort_author_az": "Auteur A–Z",
   "library.sort_progress": "Progression",
+  "library.sort_last_opened": "Dernière ouverture",
   "library.sort_series": "Série",
   "library.btn_edit": "Modifier",
   "library.add_book": "Ajouter un livre",

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -51,6 +51,7 @@
   "library.sort_title_za": "Titolo Z–A",
   "library.sort_author_az": "Autore A–Z",
   "library.sort_progress": "Progresso",
+  "library.sort_last_opened": "Ultima apertura",
   "library.btn_edit": "Modifica",
   "library.add_book": "Aggiungi libro",
   "library.upload_file": "Carica file",

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -51,6 +51,7 @@
   "library.sort_title_za": "Título Z–A",
   "library.sort_author_az": "Autor A–Z",
   "library.sort_progress": "Progresso",
+  "library.sort_last_opened": "Última abertura",
   "library.sort_series": "Série",
   "library.btn_edit": "Editar",
   "library.add_book": "Adicionar livro",

--- a/public/locales/sl.json
+++ b/public/locales/sl.json
@@ -51,6 +51,7 @@
   "library.sort_title_za": "Naslov Z–A",
   "library.sort_author_az": "Avtor A–Z",
   "library.sort_progress": "Napredek",
+  "library.sort_last_opened": "Nazadnje odprto",
   "library.sort_series": "Serija",
   "library.btn_edit": "Uredi",
   "library.add_book": "Dodaj knjigo",

--- a/server/db.js
+++ b/server/db.js
@@ -177,12 +177,28 @@ function initDb() {
     [`ALTER TABLE books          ADD COLUMN genres                   TEXT    DEFAULT ''`,  'books.genres'],
     [`ALTER TABLE books          ADD COLUMN pages                    TEXT    DEFAULT ''`,  'books.pages'],
     [`ALTER TABLE user_settings  ADD COLUMN kosync_internal_enabled  INTEGER DEFAULT 0`,   'user_settings.kosync_internal_enabled'],
+    [`ALTER TABLE books          ADD COLUMN last_opened_at          INTEGER`, 'books.last_opened_at'],
   ];
   for (const [sql, label] of migrations) {
     try {
       database.exec(sql);
       console.log(`[db] Migration: added ${label}`);
     } catch { /* column already exists — ignore */ }
+  }
+
+  // Backfill last_opened_at from last progress save, else added_at (counts as "opened when added").
+  try {
+    database.exec(`
+      UPDATE books AS b
+         SET last_opened_at = COALESCE(
+           (SELECT p.updated_at FROM reading_progress p
+             WHERE p.user_id = b.user_id AND p.document_hash = b.file_hash),
+           b.added_at
+         )
+       WHERE b.last_opened_at IS NULL
+    `);
+  } catch (e) {
+    console.warn('[db] last_opened_at backfill:', e.message);
   }
 }
 

--- a/server/routes/books.js
+++ b/server/routes/books.js
@@ -29,6 +29,7 @@ router.get('/', (req, res) => {
   const db    = getDb();
   const books = db.prepare(`
     SELECT b.id, b.title, b.author, b.series_name, b.series_number, b.file_hash, b.file_hash_md5, b.cover_path, b.file_size, b.added_at,
+           COALESCE(b.last_opened_at, b.added_at) AS last_opened_at,
            COALESCE(p.percentage, 0)    AS percentage,
            COALESCE(p.cfi_position, '') AS cfi_position,
            p.updated_at                AS progress_updated_at
@@ -39,6 +40,15 @@ router.get('/', (req, res) => {
      ORDER BY b.added_at DESC
   `).all(req.user.id);
   res.json(books);
+});
+
+// ── POST /api/books/:id/opened — record that the user opened this book ─────────
+router.post('/:id/opened', (req, res) => {
+  const db   = getDb();
+  const book = db.prepare('SELECT id FROM books WHERE id = ? AND user_id = ?').get(req.params.id, req.user.id);
+  if (!book) return res.status(404).json({ error: 'error.book_not_found' });
+  db.prepare(`UPDATE books SET last_opened_at = strftime('%s', 'now') WHERE id = ?`).run(book.id);
+  res.json({ success: true });
 });
 
 // ── GET /api/books/:id ─────────────────────────────────────────────────────────

--- a/server/routes/progress.js
+++ b/server/routes/progress.js
@@ -17,29 +17,51 @@ router.get('/:hash', (req, res) => {
 });
 
 // ── PUT /api/progress/:hash ────────────────────────────────────────────────────
+// By default this is a high-water-mark endpoint: progress only moves forward.
+// Pass ?force=1 (or body { force: true }) to overwrite unconditionally (e.g. restart book).
 router.put('/:hash', (req, res) => {
-  const { cfi_position, percentage, device } = req.body;
+  const { cfi_position, percentage, device, force: bodyForce } = req.body;
+  const forceOverwrite = bodyForce === true || req.query.force === '1';
 
   if (typeof percentage !== 'undefined' && (typeof percentage !== 'number' || percentage < 0 || percentage > 1)) {
     return res.status(400).json({ error: 'percentage mora biti število med 0 in 1' });
   }
 
-  const db = getDb();
+  const db  = getDb();
+  const pct = typeof percentage === 'number' ? percentage : 0;
+
+  if (forceOverwrite) {
+    // Unconditional overwrite — used when the user deliberately resets/jumps position
+    db.prepare(`
+      INSERT INTO reading_progress (user_id, document_hash, cfi_position, percentage, device, updated_at)
+      VALUES (?, ?, ?, ?, ?, strftime('%s', 'now'))
+      ON CONFLICT (user_id, document_hash) DO UPDATE SET
+        cfi_position = excluded.cfi_position,
+        percentage   = excluded.percentage,
+        device       = excluded.device,
+        updated_at   = excluded.updated_at
+    `).run(req.user.id, req.params.hash, String(cfi_position || ''), pct, String(device || 'web').slice(0, 64));
+  } else {
+    // High-water mark: only advance the stored position, never go backwards.
+    // Any device pushing a stale/lower percentage is silently ignored on the pct field.
+    db.prepare(`
+      INSERT INTO reading_progress (user_id, document_hash, cfi_position, percentage, device, updated_at)
+      VALUES (?, ?, ?, ?, ?, strftime('%s', 'now'))
+      ON CONFLICT (user_id, document_hash) DO UPDATE SET
+        cfi_position = CASE WHEN excluded.percentage >= reading_progress.percentage
+                            THEN excluded.cfi_position ELSE reading_progress.cfi_position END,
+        percentage   = MAX(reading_progress.percentage, excluded.percentage),
+        device       = CASE WHEN excluded.percentage >= reading_progress.percentage
+                            THEN excluded.device ELSE reading_progress.device END,
+        updated_at   = CASE WHEN excluded.percentage >= reading_progress.percentage
+                            THEN excluded.updated_at ELSE reading_progress.updated_at END
+    `).run(req.user.id, req.params.hash, String(cfi_position || ''), pct, String(device || 'web').slice(0, 64));
+  }
+
   db.prepare(`
-    INSERT INTO reading_progress (user_id, document_hash, cfi_position, percentage, device, updated_at)
-    VALUES (?, ?, ?, ?, ?, strftime('%s', 'now'))
-    ON CONFLICT (user_id, document_hash) DO UPDATE SET
-      cfi_position = excluded.cfi_position,
-      percentage   = excluded.percentage,
-      device       = excluded.device,
-      updated_at   = excluded.updated_at
-  `).run(
-    req.user.id,
-    req.params.hash,
-    String(cfi_position || ''),
-    typeof percentage === 'number' ? percentage : 0,
-    String(device || 'web').slice(0, 64)
-  );
+    UPDATE books SET last_opened_at = strftime('%s', 'now')
+     WHERE user_id = ? AND file_hash = ?
+  `).run(req.user.id, req.params.hash);
 
   res.json({ success: true });
 });


### PR DESCRIPTION
## Summary
- Adds `last_opened_at` column (backfilled from progress or `added_at`)
- New **Last opened** sort in All Books
- Currently Reading shelf defaults to last-opened order